### PR TITLE
fpga: Select ultra ram macros for flash

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -24,8 +24,8 @@ packages:
       Git: "https://github.com/pulp-platform/common_verification.git"
     dependencies: []
   tech_cells_generic:
-    revision: a9cae21902e75b1434328ecf36f85327ba5717de
-    version: 0.2.11
+    revision: 7e92d7aae3af501b7f0d96bf902ee84b50e1b5c6
+    version: 0.2.13
     source:
       Git: "https://github.com/pulp-platform/tech_cells_generic.git"
     dependencies:

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -425,12 +425,19 @@ module prim_flash_bank #(
   assign debug_flash_addr  = datapath_i ?  debug_flash_addr_i  : mem_addr          ;
   assign debug_flash_wdata = datapath_i ?  debug_flash_wdata_i : mem_wdata         ;
   assign debug_flash_wmask = datapath_i ?  debug_flash_wmask_i : {DataWidth{1'b1}} ; 
-  
+
+// Use ultraram when available
+`ifdef TARGET_VCU128
+  `define USE_ULTRARAM
+`endif
 
   prim_ram_1p #(
     .Width(DataWidth),
     .Depth(WordsPerBank),
     .DataBitsPerMask(DataWidth),
+`ifdef USE_ULTRARAM
+    .FPGAMemMacro("ultra"),
+`endif
     .MemInitFile(MemInitFile)
   ) u_mem (
     .clk_i,
@@ -456,6 +463,9 @@ module prim_flash_bank #(
     prim_ram_1p #(
       .Width(DataWidth),
       .Depth(WordsPerInfoBank),
+`ifdef USE_ULTRARAM
+      .FPGAMemMacro("ultra"),
+`endif
       .DataBitsPerMask(DataWidth)
     ) u_info_mem (
       .clk_i,

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -15,6 +15,7 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
   parameter      MemInitFile     = "", // VMEM file to initialize the memory with
   parameter  int Otp             = 0,
   parameter  bit PrintSimCfg     = 1'b1,
+  parameter      FPGAMemMacro    = "auto", // Select memory macro for FPGA
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
@@ -37,6 +38,10 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
     .DataWidth(Width),
     .ByteWidth(1),
     .NumPorts(1),
+    // Note: ifdef can be removed when all tc_sram instantiations will be compliant
+`ifdef TARGET_XILINX
+    .FPGAImplKey(FPGAMemMacro),
+`endif
     .SimInit("zeros")
  ) ram_primitive (
     .clk_i,

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
@@ -12,7 +12,7 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
   parameter  int Depth           = 128,
   parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
   parameter      MemInitFile     = "", // VMEM file to initialize the memory with
-
+  parameter      FPGAMemMacro    = "auto", // Select memory macro for FPGA
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input                    clk_a_i,
@@ -74,6 +74,10 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
      .NumPorts(32'd2),
      .PrintSimCfg(1),
      .ByteWidth(1),
+    // Note: ifdef can be removed when all tc_sram instantiations will be compliant
+`ifdef TARGET_XILINX
+    .FPGAImplKey(FPGAMemMacro),
+`endif
      .SimInit("zeros")
   ) ram_primitive (
      .clk_i(clk_a_i),


### PR DESCRIPTION
Use ultraram for the large "flash" emulation.
[Pipeline](https://iis-git.ee.ethz.ch/github-mirror/carfield/-/pipelines/77682) running on Carfield.